### PR TITLE
add vue 3 auto-complete feature

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,6 @@
 
 
 VITE_API_POSTS=/typicode/demo/posts
+
+# test
+VITE_API_AUTO_COMPLETE=/api/v1/search_keyword

--- a/.env.dev
+++ b/.env.dev
@@ -1,3 +1,4 @@
 
 NODE_ENV=dev
 VITE_API_HOST=https://my-json-server.typicode.com
+VITE_API_ATHENA=https://lab-athena.eslite.dev

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,5 +35,8 @@ module.exports = {
     'vue/singleline-html-element-content-newline': 'off',
     'import/extensions': 'off',
     'no-return-assign': 'off',
+
+    // vue3 很多 export 沒辦法關聯到
+    'no-unused-vars': 'off',
   },
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
   },
   "dependencies": {
     "axios": "^0.21.1",
+    "babel-plugin-lodash": "^3.3.4",
     "bootstrap": "^4.6.0",
+    "lodash": "^4.17.21",
+    "lodash-webpack-plugin": "^0.11.6",
     "path": "^0.12.7",
     "vue": "^3.0.5",
     "vue-cli-plugin-pug": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lodash": "^4.17.21",
     "lodash-webpack-plugin": "^0.11.6",
     "path": "^0.12.7",
+    "ramda": "^0.27.1",
     "vue": "^3.0.5",
     "vue-cli-plugin-pug": "^2.0.0",
     "vue-router": "^4.0.5"

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,10 @@
-# Vue3 auto complete practices
-**套件自行看 package.json**
-**尚未完成**
+# [Vue3] auto complete practices
+**套件自行看 package.json**，目前有使用到 `setup` 的部分
+* computed
+* watch
+* data (ref)
+* element ref
+* split file
 
 ## vue3 練習項目
 * main feature : auto complete using composition api

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,13 @@
+# Vue3 auto complete practices
+**套件自行看 package.json**
+**尚未完成**
+
+## vue3 練習項目
+* main feature : auto complete using composition api
+* vite vue router : `src/router.js`
+
+
+## 其他練習包含
+* eslint, prettier
+* lodash partial install (function) : see vite.config.js
+* bootstrap (style only) : see `src/assets/base-style.scss`

--- a/src/App.vue
+++ b/src/App.vue
@@ -23,7 +23,7 @@ const text = import.meta.env.VITE_API_HOST;
 // Check out https://github.com/vuejs/rfcs/blob/script-setup-2/active-rfcs/0000-script-setup.md
 </script>
 
-<style lang="scss">
+<style scoped lang="scss">
 $color: red;
 h1 {
   color: $color;

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,6 +3,9 @@
   h1 Axios
   h2 {{url}}
   h2 {{res()}}
+  hr
+  router-view
+  hr
   router-link(to="/about") about
   router-link(to="/home") index
   router-link(to="/recommends") recommends

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,14 +1,11 @@
 <template lang="pug">
 .container
-  h1 Axios
-  h2 {{url}}
-  h2 {{res()}}
-  hr
-  router-view
-  hr
-  router-link(to="/about") about
-  router-link(to="/home") index
-  router-link(to="/recommends") recommends
+  .d-flex.justify-content-around.bg-light.py-3
+    router-link(to="/about") about
+    router-link(to="/home") index
+    router-link(to="/recommends") recommends
+  div.mt-2
+    router-view
 </template>
 
 <script setup>

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,6 +5,7 @@
   h2 {{res()}}
   router-link(to="/about") about
   router-link(to="/home") index
+  router-link(to="/recommends") recommends
 </template>
 
 <script setup>

--- a/src/api/search.js
+++ b/src/api/search.js
@@ -1,23 +1,9 @@
 import axios from 'axios';
 
-// export default (params, cancelToken) =>
-//   axios({
-//     method: 'get',
-//     // 暫時保留：可以查到 `デザインアイディア & テクニック事典 01` 但會影響作者 `+Design`不能查
-//     // url: `${API_PATH}?${decodeURIComponent(qs.stringify(params))}`,
-//
-//     // 一般可以查的串接方式，但無法查到 `デザインアイディア & テクニック事典 01`
-//     // url: `${API_PATH}?${toQueryString(params)}`,
-//
-//     url: `${process.env.NUXT_ENV_API}${process.env.NUXT_ENV_API_SEARCH}`,
-//     params,
-//     cancelToken: cancelToken.token,
-//   });
-//
-// export const fetchRecommendWords = (params, cancelToken) =>
-//   axios({
-//     method: 'get',
-//     url: `${process.env.NUXT_ENV_API}${process.env.NUXT_ENV_API_SEARCH_KEYWORDS}`,
-//     params,
-//     cancelToken: cancelToken.token,
-//   });
+export const fetchRecommendWords = (params, cancelToken) =>
+  axios({
+    method: 'get',
+    url: `${import.meta.env.VITE_API_ATHENA}${import.meta.env.VITE_API_AUTO_COMPLETE}`,
+    params,
+    cancelToken: cancelToken.token,
+  });

--- a/src/api/search.js
+++ b/src/api/search.js
@@ -1,0 +1,23 @@
+import axios from 'axios';
+
+// export default (params, cancelToken) =>
+//   axios({
+//     method: 'get',
+//     // 暫時保留：可以查到 `デザインアイディア & テクニック事典 01` 但會影響作者 `+Design`不能查
+//     // url: `${API_PATH}?${decodeURIComponent(qs.stringify(params))}`,
+//
+//     // 一般可以查的串接方式，但無法查到 `デザインアイディア & テクニック事典 01`
+//     // url: `${API_PATH}?${toQueryString(params)}`,
+//
+//     url: `${process.env.NUXT_ENV_API}${process.env.NUXT_ENV_API_SEARCH}`,
+//     params,
+//     cancelToken: cancelToken.token,
+//   });
+//
+// export const fetchRecommendWords = (params, cancelToken) =>
+//   axios({
+//     method: 'get',
+//     url: `${process.env.NUXT_ENV_API}${process.env.NUXT_ENV_API_SEARCH_KEYWORDS}`,
+//     params,
+//     cancelToken: cancelToken.token,
+//   });

--- a/src/components/search/auto-complete-list.vue
+++ b/src/components/search/auto-complete-list.vue
@@ -54,7 +54,6 @@ const emitCurrentItem = ({ emit, list }) => (index) => {
 };
 // 離開 auto complete list： reset hover 值
 const leave = ({ hover, emitCurrentItem }) => () => {
-  console.log(' leave', hover.value);
   hover.value = hoverDefaultIndex;
   emitCurrentItem(hoverDefaultIndex);
 };

--- a/src/components/search/auto-complete-list.vue
+++ b/src/components/search/auto-complete-list.vue
@@ -1,0 +1,12 @@
+<template lang="pug">
+.list
+  .item
+</template>
+
+<script>
+export default {
+  name: 'AutoCompleteList',
+};
+</script>
+
+<style scoped></style>

--- a/src/components/search/auto-complete-list.vue
+++ b/src/components/search/auto-complete-list.vue
@@ -54,6 +54,7 @@ const emitCurrentItem = ({ emit, list }) => (index) => {
 };
 // 離開 auto complete list： reset hover 值
 const leave = ({ hover, emitCurrentItem }) => () => {
+  console.log(' leave', hover.value);
   hover.value = hoverDefaultIndex;
   emitCurrentItem(hoverDefaultIndex);
 };

--- a/src/components/search/auto-complete-list.vue
+++ b/src/components/search/auto-complete-list.vue
@@ -1,14 +1,19 @@
 <template lang="pug">
 .list
-  .item(v-for="(item, index) in items")
+  .item(v-for="(item, index) in items" :class="classIsHover(index)")
     span {{item.keyword}}
     span.font-weight-bold {{item.otherWords}}
 </template>
 
 <script>
-import { toRefs, computed } from 'vue';
+import { toRefs, computed, ref, watch } from 'vue';
 import { splitAt, map, length, pipe } from 'ramda';
+import { hoverDefaultIndex } from '@/src/constant/search/auto-complete';
 
+/**
+ * computed
+ */
+// 推薦詞集合
 const items = ({ list, keyword }) =>
   computed(() => {
     return pipe(
@@ -17,27 +22,104 @@ const items = ({ list, keyword }) =>
       map((x) => ({ keyword: x[0], otherWords: x[1] })),
     )(list.value);
   });
+// Hover 處理
+const hover = ({ hoverItem }) =>
+  computed({
+    get: () => hoverItem.value,
+    set: (value) => {
+      hoverItem.value = parseInt(value, 10);
+    },
+  });
+
+/**
+ * watch
+ */
+const watchModelValue = ({ setHover }) => (modelValue) => {
+  setHover(modelValue);
+};
+
+/**
+ * methods
+ */
+// hover 項目的 class : 變色
+const classIsHover = ({ hover }) => (index) => {
+  return { hover: hover.value === index };
+};
+// 發射事件：目前正在選擇的項目
+const emitCurrentItem = ({ emit, list }) => (index) => {
+  emit('overItem', {
+    index,
+    text: list.value[index] || '', // using source
+  });
+};
+// 離開 auto complete list： reset hover 值
+const leave = ({ hover, emitCurrentItem }) => () => {
+  hover.value = hoverDefaultIndex;
+  emitCurrentItem(hoverDefaultIndex);
+};
+// 紀錄 hover 的 index：過小視為 reset，過大以最後一個為主。
+const setHover = ({ hover, items, emitCurrentItem, leave }) => (index) => {
+  // over min
+  if (index < 0) {
+    leave();
+  }
+  // over max
+  if (index >= length(items.value)) {
+    index = 0; // 回到最前面
+    emitCurrentItem(0);
+  }
+  hover.value = index;
+};
 
 const props = {
   list: {
     type: Array,
-    default: [],
+    default: () => [],
   },
   keyword: {
     type: String,
     default: '',
   },
+  modelValue: {
+    type: Number,
+    default: hoverDefaultIndex,
+  },
 };
 
-const setup = function (props) {
-  const { list, keyword } = toRefs(props);
+const setup = function (props, context) {
+  const hoverItem = ref(hoverDefaultIndex);
+  const { list, keyword, modelValue } = toRefs(props);
+
+  // computed
+  const itemsComputed = items({ list, keyword });
+  const hoverComputed = hover({ hoverItem });
+
+  // methods
+  const emitCurrentItemMethod = emitCurrentItem({ emit: context.emit, list });
+  const leaveMethod = leave({ hover: hoverComputed, emitCurrentItem: emitCurrentItemMethod });
+  const setHoverMethod = setHover({ hover: hoverComputed, items: itemsComputed, emitCurrentItem: emitCurrentItemMethod, leave: leaveMethod });
+
+  // watch
+  watch(modelValue, watchModelValue({ setHover: setHoverMethod }));
   return {
-    items: items({ list, keyword }),
+    // data
+    hoverItem,
+
+    // computed
+    items: itemsComputed,
+    // hover: hoverComputed,
+
+    // methods
+    classIsHover: classIsHover({ hover: hoverComputed }),
+    // setHover: setHoverMethod,
+    // emitCurrentItem: emitCurrentItemMethod,
+    // leaveMethod,
   };
 };
 export default {
   name: 'AutoCompleteList',
   props,
+  emits: ['overItem'],
   setup,
 };
 </script>
@@ -47,6 +129,6 @@ div {
   border: darkgray 1px solid;
 }
 .hover {
-  background-color: aquamarine;
+  background-color: #95ccee;
 }
 </style>

--- a/src/components/search/auto-complete-list.vue
+++ b/src/components/search/auto-complete-list.vue
@@ -1,11 +1,44 @@
 <template lang="pug">
 .list
-  .item
+  .item(v-for="(item, index) in items")
+    span {{item.keyword}}
+    span.font-weight-bold {{item.otherWords}}
 </template>
 
 <script>
+import { toRefs, computed } from 'vue';
+import { splitAt, map, length, pipe } from 'ramda';
+
+const items = ({ list, keyword }) =>
+  computed(() => {
+    return pipe(
+      // reset keywords format
+      map((x) => splitAt(length(keyword.value))(x)),
+      map((x) => ({ keyword: x[0], otherWords: x[1] })),
+    )(list.value);
+  });
+
+const props = {
+  list: {
+    type: Array,
+    default: [],
+  },
+  keyword: {
+    type: String,
+    default: '',
+  },
+};
+
+const setup = function (props) {
+  const { list, keyword } = toRefs(props);
+  return {
+    items: items({ list, keyword }),
+  };
+};
 export default {
   name: 'AutoCompleteList',
+  props,
+  setup,
 };
 </script>
 

--- a/src/components/search/auto-complete-list.vue
+++ b/src/components/search/auto-complete-list.vue
@@ -42,4 +42,11 @@ export default {
 };
 </script>
 
-<style scoped></style>
+<style lang="scss" scoped>
+div {
+  border: darkgray 1px solid;
+}
+.hover {
+  background-color: aquamarine;
+}
+</style>

--- a/src/components/search/auto-complete-list.vue
+++ b/src/components/search/auto-complete-list.vue
@@ -111,9 +111,6 @@ const setup = function (props, context) {
 
     // methods
     classIsHover: classIsHover({ hover: hoverComputed }),
-    // setHover: setHoverMethod,
-    // emitCurrentItem: emitCurrentItemMethod,
-    // leaveMethod,
   };
 };
 export default {

--- a/src/constant/local-storage.js
+++ b/src/constant/local-storage.js
@@ -1,0 +1,3 @@
+export const LocalStorageKey = {
+  searchRecord: 'searchRecord',
+};

--- a/src/constant/search/auto-complete.js
+++ b/src/constant/search/auto-complete.js
@@ -1,0 +1,23 @@
+import { values } from 'ramda';
+
+export const autoCompleteCount = {
+  mobile: 3,
+  history: 5,
+  recommends: 15,
+};
+
+export const arrowKeyEnum = {
+  up: 'ArrowUp',
+  down: 'ArrowDown',
+  left: 'ArrowLeft',
+  right: 'ArrowRight',
+};
+
+export const specialKeyEnum = {
+  enter: 'Enter',
+  esc: 'Escape',
+};
+
+export const specialKeys = [...values(arrowKeyEnum), specialKeyEnum.enter];
+
+export const hoverDefaultIndex = -1;

--- a/src/constant/search/auto-complete.js
+++ b/src/constant/search/auto-complete.js
@@ -18,6 +18,8 @@ export const specialKeyEnum = {
   esc: 'Escape',
 };
 
+export const historyCount = 5;
+
 export const specialKeys = [...values(arrowKeyEnum), specialKeyEnum.enter];
 
 export const hoverDefaultIndex = -1;

--- a/src/exceptions/browser-not-support-exception.js
+++ b/src/exceptions/browser-not-support-exception.js
@@ -1,0 +1,14 @@
+export const browserNotSupportType = {
+  localStorage: 'localStorage',
+};
+
+const errorTypeDisplay = {
+  localStorage: 'Local Storage',
+};
+
+export const BrowserNotSupportException = function (type, message) {
+  message = message ? `，訊息：${message}。` : '';
+  this.message = `【瀏覽器不支援】：${errorTypeDisplay[type]}${message}`;
+  this.error = browserNotSupportType[type];
+  this.type = 'BrowserNotSupportException';
+};

--- a/src/helper/data-process.js
+++ b/src/helper/data-process.js
@@ -1,0 +1,23 @@
+import { isNil, isEmpty, filter } from 'ramda';
+
+export const isNull = (data) => data === null;
+
+export const isEmptyString = (data) => data === '';
+
+export const isStringNumber = (data) => !isNull(data.match(/^\d*$/));
+
+export const isEmptyValue = (data) => isNil(data) || isEmpty(data);
+
+export const emptyReplace = (value, defaultValue) => (isEmptyValue(value) ? defaultValue : value);
+
+export const isFunction = (data) => typeof data === 'function';
+
+export const rejectArrayNullItems = (data) => filter((any) => !isNil(any), data);
+
+export const rejectEmpty = (data) => filter((any) => !isEmptyValue(any), data);
+
+export const linkTarget = (blank) => (blank === true ? '_blank' : '_self');
+
+export const randomInteger = (excludedMax, min = 0) => Math.floor(Math.random() * excludedMax + min);
+
+export const isNumber = (num) => Number(num) === num;

--- a/src/mixins/auto-complete/fetch-recommends.js
+++ b/src/mixins/auto-complete/fetch-recommends.js
@@ -1,0 +1,35 @@
+import axios from 'axios';
+import { dropLast, length } from 'ramda';
+import autoCompleteService from '@/src/services/search/auto-complete-service';
+import { isEmptyValue } from '@/src/helper/data-process';
+import { autoCompleteCount } from '@/src/constant/search/auto-complete';
+import { ref } from 'vue';
+
+const setCancelToken = (cancelToken) => {
+  // remove prev request
+  if (cancelToken.value) {
+    cancelToken.value.cancel('cancel');
+  }
+  // set cancelToken
+  cancelToken.value = axios.CancelToken.source();
+};
+
+export const fetchRecommends = ({ searchKeywords, recommendKeywords, items }) => (keyword) => {
+  const cancelToken = ref(null);
+  setCancelToken(cancelToken);
+
+  // call auto complete api
+  return autoCompleteService
+    .get(keyword, cancelToken.value)
+    .then((recommends) => {
+      // 已切換回 history，避免 debounce 過慢，後蓋前。
+      if (isEmptyValue(searchKeywords.value)) return;
+      recommendKeywords.value = recommends.keyword;
+      items.value = dropLast(length(recommends.list) - autoCompleteCount.recommends, recommends.list);
+    })
+    .catch((error) => {
+      // 預期內的 cancel，不算在 error
+      if (error?.message === 'cancel') return;
+      console.log(error);
+    });
+};

--- a/src/mixins/auto-complete/fetch-recommends.js
+++ b/src/mixins/auto-complete/fetch-recommends.js
@@ -1,3 +1,7 @@
+/**
+ *  fetch remote recommends
+ *  取得遠端關鍵字
+ */
 import axios from 'axios';
 import { dropLast, length } from 'ramda';
 import autoCompleteService from '@/src/services/search/auto-complete-service';

--- a/src/mixins/auto-complete/get-recommends.js
+++ b/src/mixins/auto-complete/get-recommends.js
@@ -1,0 +1,20 @@
+import { debounce } from 'lodash/function';
+import { trim } from 'ramda';
+import { isEmptyValue } from '@/src/helper/data-process';
+
+const getRecommends = ({ getLocal, getRemote, showRecommends }) => async (input) => {
+  const words = trim(input || '');
+  // 關鍵字空的跑 history
+  if (isEmptyValue(words)) {
+    getLocal();
+    // 關鍵字有內容 -> 問 api
+  } else {
+    await getRemote(words);
+  }
+  showRecommends();
+};
+
+export const debounceGetRecommends = ({ getLocal, getRemote, showRecommends }) =>
+  debounce(async (input) => {
+    await getRecommends({ getLocal, getRemote, showRecommends })(input);
+  }, 100);

--- a/src/mixins/auto-complete/get-recommends.js
+++ b/src/mixins/auto-complete/get-recommends.js
@@ -1,3 +1,6 @@
+/**
+ *  取得關鍵字統整（local & remote）
+ */
 import { debounce } from 'lodash/function';
 import { trim } from 'ramda';
 import { isEmptyValue } from '@/src/helper/data-process';

--- a/src/mixins/auto-complete/local-recommends.js
+++ b/src/mixins/auto-complete/local-recommends.js
@@ -1,7 +1,5 @@
 import LocalRecordsService from '@/src/services/search/local-records-service';
 import LocalStorageServices from '@/src/services/local-storage-services';
-import { isEmptyValue } from '@/src/helper/data-process';
-import { trim } from 'ramda';
 
 export const getLocalRecordsService = () => {
   try {

--- a/src/mixins/auto-complete/local-recommends.js
+++ b/src/mixins/auto-complete/local-recommends.js
@@ -1,0 +1,24 @@
+import LocalRecordsService from '@/src/services/search/local-records-service';
+import LocalStorageServices from '@/src/services/local-storage-services';
+import { isEmptyValue } from '@/src/helper/data-process';
+import { trim } from 'ramda';
+
+export const getLocalRecordsService = () => {
+  try {
+    return new LocalRecordsService(new LocalStorageServices(Storage, localStorage));
+  } catch (error) {
+    console.log(error.message);
+    return {
+      get: () => [],
+      save: (val) => null,
+    };
+  }
+};
+export const getLocalRecommends = ({ items, recommendKeywords, localService }) => () => {
+  items.value = [...(localService.get() || [])];
+  recommendKeywords.value = '';
+};
+
+export const setLocalRecommends = ({ searchKeywords, localService }) => () => {
+  localService.save(searchKeywords.value);
+};

--- a/src/mixins/auto-complete/local-recommends.js
+++ b/src/mixins/auto-complete/local-recommends.js
@@ -1,3 +1,7 @@
+/**
+ *  local recommends
+ *   - local storage 關鍵字存取
+ */
 import LocalRecordsService from '@/src/services/search/local-records-service';
 import LocalStorageServices from '@/src/services/local-storage-services';
 

--- a/src/mixins/auto-complete/recommends-data.js
+++ b/src/mixins/auto-complete/recommends-data.js
@@ -1,0 +1,16 @@
+import { ref } from 'vue';
+import { hoverDefaultIndex } from '@/src/constant/search/auto-complete';
+
+// fake data
+const fakeResponse = ['貓貓蟲咖波', '貓貓蟲咖波: 奇幻太空之旅', '貓貓蟲咖波: 小萌物到處玩', '貓貓蟲咖波: 暖暖春天文具組, 陪你慵懶每一天', '貓貓蟲咖波: 縮小世界大冒險', '貓貓蟲咖波: 食物世界超棒'];
+
+// hover
+export const hoverIndex = ref(hoverDefaultIndex);
+export const hoverItemName = ref('');
+
+// recommends source
+export const recommendItems = ref([]);
+recommendItems.value = fakeResponse; // fake
+
+// recommend list control
+export const isShowRecommends = ref(false);

--- a/src/mixins/auto-complete/recommends-data.js
+++ b/src/mixins/auto-complete/recommends-data.js
@@ -1,3 +1,7 @@
+/**
+ *  use-auto-complete.js 中，定義變數的部分
+ *   - vue data
+ */
 import { ref } from 'vue';
 import { hoverDefaultIndex } from '@/src/constant/search/auto-complete';
 

--- a/src/mixins/auto-complete/recommends-data.js
+++ b/src/mixins/auto-complete/recommends-data.js
@@ -2,6 +2,7 @@ import { ref } from 'vue';
 import { hoverDefaultIndex } from '@/src/constant/search/auto-complete';
 
 // fake data
+// todo: 暫時保留測試用 recommendItems.value = [...fakeResponse];
 const fakeResponse = ['貓貓蟲咖波', '貓貓蟲咖波: 奇幻太空之旅', '貓貓蟲咖波: 小萌物到處玩', '貓貓蟲咖波: 暖暖春天文具組, 陪你慵懶每一天', '貓貓蟲咖波: 縮小世界大冒險', '貓貓蟲咖波: 食物世界超棒'];
 
 // hover
@@ -10,7 +11,6 @@ export const hoverItemName = ref('');
 
 // recommends source
 export const recommendItems = ref([]);
-recommendItems.value = fakeResponse; // fake
 
 // recommend list control
 export const isShowRecommends = ref(false);

--- a/src/mixins/auto-complete/use-auto-complete.js
+++ b/src/mixins/auto-complete/use-auto-complete.js
@@ -1,5 +1,5 @@
 import { computed, ref } from 'vue';
-import { length, dropLast, includes } from 'ramda';
+import { length, dropLast, includes, values } from 'ramda';
 import { hoverDefaultIndex, arrowKeyEnum, specialKeyEnum } from '@/src/constant/search/auto-complete';
 import { isEmptyValue } from '@/src/helper/data-process';
 import { getLocalRecordsService, getLocalRecommends, setLocalRecommends } from '@/src/mixins/auto-complete/local-recommends';
@@ -61,7 +61,7 @@ const normalKeyProcess = ({ isInvalidHover, hideRecommends, getRecommends }) => 
   if (event.key === specialKeyEnum.esc) return;
 
   // isArrowUpDown
-  if (includes(event.key, [arrowKeyEnum.up, arrowKeyEnum.down])) return;
+  if (includes(event.key, values(arrowKeyEnum))) return;
 
   // [mac] 注音輸入法輸入中會以底線的方式 ___  先把完成的字咬住，最後搭配 `enter` 才將完整的字帶入 `this.query(input)`，所以這邊 enter 不能完全濾掉。
   if (event.key === specialKeyEnum.enter && !isInvalidHover()) return;

--- a/src/mixins/auto-complete/use-auto-complete.js
+++ b/src/mixins/auto-complete/use-auto-complete.js
@@ -1,0 +1,18 @@
+import { ref } from 'vue';
+import { hoverDefaultIndex, arrowKeyEnum } from '@/src/constant/search/auto-complete';
+
+/**
+ * key events
+ */
+const keyDown = ({ hoverIndex }) => (event) => {
+  if (event.key === arrowKeyEnum.down) hoverIndex.value += 1;
+  if (event.key === arrowKeyEnum.up) hoverIndex.value -= 1;
+};
+
+export default function () {
+  const hoverIndex = ref(hoverDefaultIndex);
+  return {
+    hoverIndex,
+    keyDown: keyDown({ hoverIndex }),
+  };
+}

--- a/src/mixins/auto-complete/use-auto-complete.js
+++ b/src/mixins/auto-complete/use-auto-complete.js
@@ -1,3 +1,6 @@
+/**
+ *  mixin : recommends.vue
+ */
 import { computed, ref } from 'vue';
 import { length, dropLast, includes, values } from 'ramda';
 import { hoverDefaultIndex, arrowKeyEnum, specialKeyEnum } from '@/src/constant/search/auto-complete';

--- a/src/mixins/auto-complete/use-auto-complete.js
+++ b/src/mixins/auto-complete/use-auto-complete.js
@@ -113,7 +113,6 @@ export default function ({ searchKeywords, searchButton, recommendKeywords }) {
     isInvalidHover: isInvalidHoverMethod,
   });
   const getLocal = getLocalRecommends({ items: itemsComputed, recommendKeywords, localService: localRecordsService });
-  // const setLocal = setLocalRecommends({ searchKeywords, localService: localRecordsService });
   const getRemote = fetchRecommends({ searchKeywords, recommendKeywords, items: itemsComputed });
   const getRecommends = debounceGetRecommends({ getLocal, getRemote, showRecommends: showRecommendsMethod });
 
@@ -135,5 +134,6 @@ export default function ({ searchKeywords, searchButton, recommendKeywords }) {
     keyUp: keyUp({ escapeInput: escapeInputMethod, confirmHover: confirmHoverMethod, normalKeyProcess: normalKeyProcessMethod }),
     overItem: overItem({ hoverIndex, hoverItemName }),
     focusInput: focusInputMethod,
+    setLocal: setLocalRecommends({ searchKeywords, localService: localRecordsService }),
   };
 }

--- a/src/mixins/auto-complete/use-auto-complete.js
+++ b/src/mixins/auto-complete/use-auto-complete.js
@@ -31,7 +31,6 @@ const keyDown = ({ hoverIndex }) => (event) => {
 };
 
 const keyUp = ({ escapeInput, confirmHover, normalKeyProcess }) => (event) => {
-  console.log(event.key);
   if (event.key === specialKeyEnum.esc) {
     escapeInput();
   }
@@ -60,20 +59,15 @@ const overItem = ({ hoverIndex, hoverItemName }) => (recommend) => {
 const normalKeyProcess = ({ isInvalidHover, hideRecommends, getRecommends }) => (event) => {
   // special keys
   if (event.key === specialKeyEnum.esc) return;
+
   // isArrowUpDown
   if (includes(event.key, [arrowKeyEnum.up, arrowKeyEnum.down])) return;
 
   // [mac] 注音輸入法輸入中會以底線的方式 ___  先把完成的字咬住，最後搭配 `enter` 才將完整的字帶入 `this.query(input)`，所以這邊 enter 不能完全濾掉。
   if (event.key === specialKeyEnum.enter && !isInvalidHover()) return;
-  // todo : check axios 能不能把後面拿掉
-  // if (event.key === specialKeyEnum.enter) return;
 
-  // console.log(event.key === specialKeyEnum.enter);
-  // console.log('isInvalidHover()', isInvalidHover(), ' ! ', !isInvalidHover());
   // clear before
   hideRecommends();
-
-  console.log('normalKeyProcess ==>', 'get!!');
 
   // get recommends
   getRecommends(event.target.value);

--- a/src/mixins/auto-complete/use-auto-complete.js
+++ b/src/mixins/auto-complete/use-auto-complete.js
@@ -1,4 +1,5 @@
 import { ref } from 'vue';
+import { length } from 'ramda';
 import { hoverDefaultIndex, arrowKeyEnum } from '@/src/constant/search/auto-complete';
 
 /**
@@ -9,10 +10,30 @@ const keyDown = ({ hoverIndex }) => (event) => {
   if (event.key === arrowKeyEnum.up) hoverIndex.value -= 1;
 };
 
-export default function () {
+/**
+ * auto complete display control
+ */
+const hideRecommends = ({ hoverIndex, isShowRecommends }) => () => {
+  hoverIndex.value = hoverDefaultIndex;
+  isShowRecommends.value = false;
+};
+
+const overItem = ({ hoverIndex, hoverItemName }) => (recommend) => {
+  hoverIndex.value = recommend.index;
+  hoverItemName.value = recommend.text;
+};
+
+export default function ({ searchKeywords }) {
+  // the hover recommend
   const hoverIndex = ref(hoverDefaultIndex);
+  const hoverItemName = ref('');
+  // recommend list control
+  const isShowRecommends = ref(false);
   return {
     hoverIndex,
+    hoverItemName,
+    isShowRecommends,
     keyDown: keyDown({ hoverIndex }),
+    overItem: overItem({ hoverIndex, hoverItemName }),
   };
 }

--- a/src/mixins/auto-complete/use-auto-complete.js
+++ b/src/mixins/auto-complete/use-auto-complete.js
@@ -1,6 +1,24 @@
-import { ref } from 'vue';
-import { length } from 'ramda';
-import { hoverDefaultIndex, arrowKeyEnum } from '@/src/constant/search/auto-complete';
+import { computed, ref } from 'vue';
+import { length, map, pipe, splitAt, dropLast } from 'ramda';
+import { hoverDefaultIndex, arrowKeyEnum, specialKeyEnum } from '@/src/constant/search/auto-complete';
+
+// fake data
+const fakeResponse = ['貓貓蟲咖波', '貓貓蟲咖波: 奇幻太空之旅', '貓貓蟲咖波: 小萌物到處玩', '貓貓蟲咖波: 暖暖春天文具組, 陪你慵懶每一天', '貓貓蟲咖波: 縮小世界大冒險', '貓貓蟲咖波: 食物世界超棒'];
+
+/**
+ * computed
+ */
+// 推薦詞集合
+const items = ({ recommendItems }) =>
+  computed({
+    get: () => {
+      const showLength = 5;
+      return dropLast(length(recommendItems.value) - showLength)([...recommendItems.value]);
+    },
+    set: (value) => {
+      recommendItems.value = [...value];
+    },
+  });
 
 /**
  * key events
@@ -10,8 +28,29 @@ const keyDown = ({ hoverIndex }) => (event) => {
   if (event.key === arrowKeyEnum.up) hoverIndex.value -= 1;
 };
 
+const keyUp = ({ confirmHover }) => (event) => {
+  if (event.key === specialKeyEnum.esc) {
+    // this.escapeInput();
+  }
+
+  // this.normalKeyProcess(event);
+  confirmHover(event);
+};
+
 /**
- * auto complete display control
+ * auto complete `content` control
+ */
+const confirmHover = ({ searchKeywords, hideRecommends, items, hoverIndex }) => (event) => {
+  // 未 hover 或資料異常
+  // if (this.isInvalidHover()) return;
+  // enter
+  if (event.key !== specialKeyEnum.enter) return;
+  searchKeywords.value = items.value[hoverIndex.value];
+  hideRecommends();
+};
+
+/**
+ * auto complete `display` control
  */
 const hideRecommends = ({ hoverIndex, isShowRecommends }) => () => {
   hoverIndex.value = hoverDefaultIndex;
@@ -27,13 +66,26 @@ export default function ({ searchKeywords }) {
   // the hover recommend
   const hoverIndex = ref(hoverDefaultIndex);
   const hoverItemName = ref('');
+  // recommends source
+  const recommendItems = ref([]);
+  recommendItems.value = fakeResponse; // fake
   // recommend list control
   const isShowRecommends = ref(false);
+
+  // computed
+  const itemsComputed = items({ recommendItems });
+
+  // methods
+  const hideRecommendsMethod = hideRecommends({ hoverIndex, isShowRecommends });
+  const confirmHoverMethod = confirmHover({ searchKeywords, hideRecommends: hideRecommendsMethod, items: itemsComputed, hoverIndex });
+
   return {
     hoverIndex,
     hoverItemName,
     isShowRecommends,
+    items: itemsComputed,
     keyDown: keyDown({ hoverIndex }),
+    keyUp: keyUp({ confirmHover: confirmHoverMethod }),
     overItem: overItem({ hoverIndex, hoverItemName }),
   };
 }

--- a/src/mixins/auto-complete/use-define-auto-complete-data.js
+++ b/src/mixins/auto-complete/use-define-auto-complete-data.js
@@ -1,3 +1,8 @@
+/**
+ *  mixin : recommends.vue
+ *   - 宣告參數的部分 ( vue data() )
+ */
+
 import { ref } from 'vue';
 
 export default function () {

--- a/src/mixins/auto-complete/use-define-auto-complete-data.js
+++ b/src/mixins/auto-complete/use-define-auto-complete-data.js
@@ -1,0 +1,12 @@
+import { ref } from 'vue';
+
+export default function () {
+  const searchButton = ref(null);
+  const searchKeywords = ref('');
+  const recommendKeywords = ref('');
+  return {
+    searchButton,
+    searchKeywords,
+    recommendKeywords,
+  };
+}

--- a/src/pages/recommends.vue
+++ b/src/pages/recommends.vue
@@ -37,9 +37,7 @@ const submitStopping = ({ searchKeywords }) => (event) => {
     event.preventDefault();
     return false;
   }
-  event.preventDefault();
-  return false;
-  // return true;
+  return true;
 };
 
 const setup = function (props, context) {

--- a/src/pages/recommends.vue
+++ b/src/pages/recommends.vue
@@ -4,10 +4,8 @@ h1 recommends
 
 <script>
 export default {
-name: "recommends"
-}
+  name: 'Recommends',
+};
 </script>
 
-<style scoped>
-
-</style>
+<style scoped></style>

--- a/src/pages/recommends.vue
+++ b/src/pages/recommends.vue
@@ -1,10 +1,29 @@
 <template lang="pug">
-h1 recommends
+.test-display
+  span hover Index
+  h3 {{ undefined || 'none'}}
+  span v-model
+  h3 {{ searchKeywords }}
+.row.col-6
+  form.d-flex.w-100
+    input.form-control.w-75(v-model="searchKeywords")
+    button.btn.btn-secondary -x-) |||
+auto-complete-list
 </template>
 
 <script>
+import { ref } from 'vue';
+import AutoCompleteList from '@/src/components/search/auto-complete-list.vue';
+
+const setup = function () {
+  const searchKeywords = ref('');
+  return { searchKeywords };
+};
+
 export default {
   name: 'Recommends',
+  components: { AutoCompleteList },
+  setup,
 };
 </script>
 

--- a/src/pages/recommends.vue
+++ b/src/pages/recommends.vue
@@ -28,21 +28,25 @@ import useAutoComplete from '@/src/mixins/auto-complete/use-auto-complete';
 import useDefineAutoCompleteData from '@/src/mixins/auto-complete/use-define-auto-complete-data';
 import { isEmptyValue } from '@/src/helper/data-process';
 
+// constant
+import { hoverDefaultIndex } from '@/src/constant/search/auto-complete';
+
 // helper
 // x
 
 // methods
-const submitStopping = ({ searchKeywords }) => (event) => {
+const submitStopping = ({ searchKeywords, hoverIndex, setLocal }) => (event) => {
   if (isEmptyValue(searchKeywords.value)) {
     event.preventDefault();
     return false;
   }
+  if (hoverIndex.value === hoverDefaultIndex) setLocal();
   return true;
 };
 
 const setup = function (props, context) {
   const { searchKeywords, searchButton, recommendKeywords } = useDefineAutoCompleteData();
-  const { isShowRecommends, hoverIndex, hoverItemName, keyDown, keyUp, overItem, items, focusInput } = useAutoComplete({ searchKeywords, searchButton, recommendKeywords });
+  const { isShowRecommends, hoverIndex, hoverItemName, keyDown, keyUp, overItem, items, focusInput, setLocal } = useAutoComplete({ searchKeywords, searchButton, recommendKeywords });
 
   return {
     // ref
@@ -59,7 +63,7 @@ const setup = function (props, context) {
     keyUp,
     keyDown,
     overItem,
-    submitStopping: submitStopping({ searchKeywords, searchButton }),
+    submitStopping: submitStopping({ searchKeywords, hoverIndex, setLocal }),
     focusInput,
   };
 };

--- a/src/pages/recommends.vue
+++ b/src/pages/recommends.vue
@@ -1,11 +1,13 @@
 <template lang="pug">
-h1 index
+h1 recommends
 </template>
 
 <script>
 export default {
-  name: 'Home',
-};
+name: "recommends"
+}
 </script>
 
-<style scoped></style>
+<style scoped>
+
+</style>

--- a/src/pages/recommends.vue
+++ b/src/pages/recommends.vue
@@ -1,9 +1,11 @@
 <template lang="pug">
 .test-display
-  span hover Index
-  h3 {{ undefined || 'none'}}
-  span v-model
-  h3 {{ searchKeywords }}
+  div
+    span v-model / searchKeywords
+    h4 {{searchKeywords}}
+  div
+    span recommendKeywords
+    h4 {{recommendKeywords}}
   div
     span hover Index
     h4 {{hoverIndex}}
@@ -18,23 +20,18 @@
 </template>
 
 <script>
-// package
-import { ref } from 'vue';
-
 // components
 import AutoCompleteList from '@/src/components/search/auto-complete-list.vue';
 
 // mixins or composition api
 import useAutoComplete from '@/src/mixins/auto-complete/use-auto-complete';
+import useDefineAutoCompleteData from '@/src/mixins/auto-complete/use-define-auto-complete-data';
 import { isEmptyValue } from '@/src/helper/data-process';
 
 // helper
 // x
 
 // methods
-const focusOther = () => () => {
-  // this.$refs.searchButton.focus();
-};
 const submitStopping = ({ searchKeywords }) => (event) => {
   if (isEmptyValue(searchKeywords.value)) {
     event.preventDefault();
@@ -46,16 +43,17 @@ const submitStopping = ({ searchKeywords }) => (event) => {
 };
 
 const setup = function (props, context) {
-  const searchButton = ref(null);
-  const searchKeywords = ref('');
-  const { isShowRecommends, hoverIndex, hoverItemName, keyDown, keyUp, overItem, items, focusInput } = useAutoComplete({ searchKeywords, searchButton });
+  const { searchKeywords, searchButton, recommendKeywords } = useDefineAutoCompleteData();
+  const { isShowRecommends, hoverIndex, hoverItemName, keyDown, keyUp, overItem, items, focusInput } = useAutoComplete({ searchKeywords, searchButton, recommendKeywords });
 
   return {
     // ref
     searchButton,
     // data
-    isShowRecommends,
     searchKeywords,
+    recommendKeywords,
+
+    isShowRecommends,
     hoverIndex,
     hoverItemName,
     items,

--- a/src/pages/recommends.vue
+++ b/src/pages/recommends.vue
@@ -4,20 +4,28 @@
   h3 {{ undefined || 'none'}}
   span v-model
   h3 {{ searchKeywords }}
+  //div
+    span is ?
+    h4 {{recommendList}}
 .row.col-6
   form.d-flex.w-100
     input.form-control.w-75(v-model="searchKeywords")
     button.btn.btn-secondary -x-) |||
-auto-complete-list
+auto-complete-list(:list="recommendList")
 </template>
 
 <script>
 import { ref } from 'vue';
 import AutoCompleteList from '@/src/components/search/auto-complete-list.vue';
 
+const fakeResponse = ['貓貓蟲咖波', '貓貓蟲咖波: 奇幻太空之旅', '貓貓蟲咖波: 小萌物到處玩', '貓貓蟲咖波: 暖暖春天文具組, 陪你慵懶每一天', '貓貓蟲咖波: 縮小世界大冒險', '貓貓蟲咖波: 食物世界超棒'];
+
 const setup = function () {
   const searchKeywords = ref('');
-  return { searchKeywords };
+  return {
+    searchKeywords,
+    recommendList: fakeResponse,
+  };
 };
 
 export default {

--- a/src/pages/recommends.vue
+++ b/src/pages/recommends.vue
@@ -11,7 +11,8 @@
   form.d-flex.w-100
     input.form-control.w-75(v-model="searchKeywords" @keydown="keyDown")
     button.btn.btn-secondary -x-) |||
-auto-complete-list(:list="recommendList" :keyword="searchKeywords")
+.row.col-6
+  auto-complete-list.w-75(:list="recommendList" :keyword="searchKeywords")
 </template>
 
 <script>

--- a/src/pages/recommends.vue
+++ b/src/pages/recommends.vue
@@ -1,5 +1,7 @@
 <template lang="pug">
-.test-display
+.row.col-12
+  h1 auto complete
+//.test-display
   div
     span v-model / searchKeywords
     h4 {{searchKeywords}}

--- a/src/pages/recommends.vue
+++ b/src/pages/recommends.vue
@@ -4,27 +4,38 @@
   h3 {{ undefined || 'none'}}
   span v-model
   h3 {{ searchKeywords }}
-  //div
-    span is ?
-    h4 {{recommendList}}
+  div
+    span hover Index
+    h4 {{hoverIndex}}
 .row.col-6
   form.d-flex.w-100
-    input.form-control.w-75(v-model="searchKeywords")
+    input.form-control.w-75(v-model="searchKeywords" @keydown="keyDown")
     button.btn.btn-secondary -x-) |||
-auto-complete-list(:list="recommendList")
+auto-complete-list(:list="recommendList" :keyword="searchKeywords")
 </template>
 
 <script>
+// package
 import { ref } from 'vue';
+
+// components
 import AutoCompleteList from '@/src/components/search/auto-complete-list.vue';
+
+// mixins or composition api
+import useAutoComplete from '@/src/mixins/auto-complete/use-auto-complete';
+
+// helper
 
 const fakeResponse = ['貓貓蟲咖波', '貓貓蟲咖波: 奇幻太空之旅', '貓貓蟲咖波: 小萌物到處玩', '貓貓蟲咖波: 暖暖春天文具組, 陪你慵懶每一天', '貓貓蟲咖波: 縮小世界大冒險', '貓貓蟲咖波: 食物世界超棒'];
 
 const setup = function () {
   const searchKeywords = ref('');
+  const { hoverIndex, keyDown } = useAutoComplete();
   return {
     searchKeywords,
     recommendList: fakeResponse,
+    hoverIndex,
+    keyDown,
   };
 };
 

--- a/src/pages/recommends.vue
+++ b/src/pages/recommends.vue
@@ -8,11 +8,12 @@
     span hover Index
     h4 {{hoverIndex}}
 .row.col-6
-  form.d-flex.w-100
-    input.form-control.w-75(v-model="searchKeywords" @keydown="keyDown")
+  form.d-flex.w-100(@submit="submitStopping")
+    input.form-control.w-75(v-model="searchKeywords"
+      @keydown="keyDown" @keyup="keyUp")
     button.btn.btn-secondary -x-) |||
 .row.col-6
-  auto-complete-list.w-75(:list="recommendList" :keyword="searchKeywords" :modelValue="hoverIndex"
+  auto-complete-list.w-75(:list="items" :keyword="searchKeywords" :modelValue="hoverIndex"
     @overItem="overItem")
 </template>
 
@@ -25,21 +26,33 @@ import AutoCompleteList from '@/src/components/search/auto-complete-list.vue';
 
 // mixins or composition api
 import useAutoComplete from '@/src/mixins/auto-complete/use-auto-complete';
+import { isEmptyValue } from '@/src/helper/data-process';
 
 // helper
-
-const fakeResponse = ['貓貓蟲咖波', '貓貓蟲咖波: 奇幻太空之旅', '貓貓蟲咖波: 小萌物到處玩', '貓貓蟲咖波: 暖暖春天文具組, 陪你慵懶每一天', '貓貓蟲咖波: 縮小世界大冒險', '貓貓蟲咖波: 食物世界超棒'];
+const submitStopping = ({ searchKeywords }) => (event) => {
+  if (isEmptyValue(searchKeywords.value)) {
+    event.preventDefault();
+    return false;
+  }
+  event.preventDefault();
+  return false;
+  // return true;
+};
 
 const setup = function () {
   const searchKeywords = ref('');
-  const { hoverIndex, hoverItemName, keyDown, overItem } = useAutoComplete({ searchKeywords });
+  const { hoverIndex, hoverItemName, keyDown, keyUp, overItem, items } = useAutoComplete({ searchKeywords });
   return {
+    // data
     searchKeywords,
-    recommendList: fakeResponse,
     hoverIndex,
     hoverItemName,
+    items,
+    // methods
+    keyUp,
     keyDown,
     overItem,
+    submitStopping: submitStopping({ searchKeywords }),
   };
 };
 

--- a/src/pages/recommends.vue
+++ b/src/pages/recommends.vue
@@ -12,7 +12,8 @@
     input.form-control.w-75(v-model="searchKeywords" @keydown="keyDown")
     button.btn.btn-secondary -x-) |||
 .row.col-6
-  auto-complete-list.w-75(:list="recommendList" :keyword="searchKeywords")
+  auto-complete-list.w-75(:list="recommendList" :keyword="searchKeywords" :modelValue="hoverIndex"
+    @overItem="overItem")
 </template>
 
 <script>
@@ -31,12 +32,14 @@ const fakeResponse = ['貓貓蟲咖波', '貓貓蟲咖波: 奇幻太空之旅', 
 
 const setup = function () {
   const searchKeywords = ref('');
-  const { hoverIndex, keyDown } = useAutoComplete();
+  const { hoverIndex, hoverItemName, keyDown, overItem } = useAutoComplete({ searchKeywords });
   return {
     searchKeywords,
     recommendList: fakeResponse,
     hoverIndex,
+    hoverItemName,
     keyDown,
+    overItem,
   };
 };
 

--- a/src/pages/recommends.vue
+++ b/src/pages/recommends.vue
@@ -10,10 +10,10 @@
 .row.col-6
   form.d-flex.w-100(@submit="submitStopping")
     input.form-control.w-75(v-model="searchKeywords"
-      @keydown="keyDown" @keyup="keyUp")
-    button.btn.btn-secondary -x-) |||
+      @keydown="keyDown" @keyup="keyUp" @focus="focusInput")
+    button.btn.btn-secondary(ref="searchButton") -x-) |||
 .row.col-6
-  auto-complete-list.w-75(:list="items" :keyword="searchKeywords" :modelValue="hoverIndex"
+  auto-complete-list.w-75(v-if="isShowRecommends" :list="items" :keyword="searchKeywords" :modelValue="hoverIndex"
     @overItem="overItem")
 </template>
 
@@ -29,6 +29,12 @@ import useAutoComplete from '@/src/mixins/auto-complete/use-auto-complete';
 import { isEmptyValue } from '@/src/helper/data-process';
 
 // helper
+// x
+
+// methods
+const focusOther = () => () => {
+  // this.$refs.searchButton.focus();
+};
 const submitStopping = ({ searchKeywords }) => (event) => {
   if (isEmptyValue(searchKeywords.value)) {
     event.preventDefault();
@@ -39,11 +45,16 @@ const submitStopping = ({ searchKeywords }) => (event) => {
   // return true;
 };
 
-const setup = function () {
+const setup = function (props, context) {
+  const searchButton = ref(null);
   const searchKeywords = ref('');
-  const { hoverIndex, hoverItemName, keyDown, keyUp, overItem, items } = useAutoComplete({ searchKeywords });
+  const { isShowRecommends, hoverIndex, hoverItemName, keyDown, keyUp, overItem, items, focusInput } = useAutoComplete({ searchKeywords, searchButton });
+
   return {
+    // ref
+    searchButton,
     // data
+    isShowRecommends,
     searchKeywords,
     hoverIndex,
     hoverItemName,
@@ -52,7 +63,8 @@ const setup = function () {
     keyUp,
     keyDown,
     overItem,
-    submitStopping: submitStopping({ searchKeywords }),
+    submitStopping: submitStopping({ searchKeywords, searchButton }),
+    focusInput,
   };
 };
 

--- a/src/router.js
+++ b/src/router.js
@@ -11,6 +11,11 @@ const routes = [
     name: 'About',
     component: () => import('@/src/pages/about.vue'),
   },
+  {
+    path: "/recommends",
+    name: "recommends",
+    component: () => import('@/src/pages/recommends.vue'),
+  },
 ];
 
 export default createRouter({

--- a/src/router.js
+++ b/src/router.js
@@ -12,8 +12,8 @@ const routes = [
     component: () => import('@/src/pages/about.vue'),
   },
   {
-    path: "/recommends",
-    name: "recommends",
+    path: '/recommends',
+    name: 'recommends',
     component: () => import('@/src/pages/recommends.vue'),
   },
 ];

--- a/src/services/local-storage-services.js
+++ b/src/services/local-storage-services.js
@@ -1,0 +1,20 @@
+import { isEmptyValue } from '@/src/helper/data-process';
+
+export default class LocalStorageServices {
+  constructor(storage, localStorage) {
+    this.storage = storage;
+    this.local = localStorage;
+  }
+
+  isSupport() {
+    return !isEmptyValue(this.storage);
+  }
+
+  get(key, defaultValue) {
+    return JSON.parse(this.local.getItem(key)) || defaultValue;
+  }
+
+  set(key, data) {
+    this.local.setItem(key, JSON.stringify(data));
+  }
+}

--- a/src/services/search/auto-complete-service.js
+++ b/src/services/search/auto-complete-service.js
@@ -1,0 +1,12 @@
+import { fetchRecommendWords } from '@/src/api/search';
+
+const get = (keyword, cancelToken) => {
+  return fetchRecommendWords({ q: keyword }, cancelToken).then((res) => ({
+    keyword,
+    list: res?.data?.keyword || [],
+  }));
+};
+
+export default {
+  get,
+};

--- a/src/services/search/local-records-service.js
+++ b/src/services/search/local-records-service.js
@@ -1,0 +1,39 @@
+import { dropLast, pipe, length, ifElse, uniq, prepend } from 'ramda';
+import { LocalStorageKey } from '@/src/constant/local-storage';
+import { historyCount } from '@/src/constant/search/search';
+import { BrowserNotSupportException, browserNotSupportType } from '@/src/exceptions/browser-not-support-exception';
+
+/**
+ * 移除超過的紀錄筆數
+ */
+const isRedundant = (records) => length(records) > historyCount;
+const dropRedundant = (records) => dropLast(length(records) - historyCount, records);
+const removeRedundant = ifElse(isRedundant, dropRedundant, (x) => x);
+
+export default class LocalRecordsService {
+  constructor(localStorageService) {
+    /** localStorageService */
+    this.localStorageService = localStorageService;
+    this.key = LocalStorageKey.searchRecord;
+    this.check();
+  }
+
+  isSupport() {
+    return this.localStorageService.isSupport();
+  }
+
+  check() {
+    if (!this.isSupport()) throw new BrowserNotSupportException(browserNotSupportType.localStorage);
+  }
+
+  get() {
+    if (!this.isSupport()) return [];
+    return this.localStorageService.get(this.key, []);
+  }
+
+  save(keyword) {
+    if (!this.isSupport()) return;
+    const prependRecords = pipe(prepend(keyword), uniq, removeRedundant);
+    this.localStorageService.set(this.key, prependRecords(this.get()));
+  }
+}

--- a/src/services/search/local-records-service.js
+++ b/src/services/search/local-records-service.js
@@ -1,6 +1,6 @@
 import { dropLast, pipe, length, ifElse, uniq, prepend } from 'ramda';
 import { LocalStorageKey } from '@/src/constant/local-storage';
-import { historyCount } from '@/src/constant/search/search';
+import { historyCount } from '@/src/constant/search/auto-complete';
 import { BrowserNotSupportException, browserNotSupportType } from '@/src/exceptions/browser-not-support-exception';
 
 /**

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,12 +1,13 @@
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import { resolve } from 'path';
+import LodashWebpackPlugin from 'lodash-webpack-plugin';
 
 console.log(resolve(__dirname, ''));
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [vue(), new LodashWebpackPlugin({ function: true })],
   resolve: {
     alias: {
       '@': resolve(__dirname, ''),

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,8 +3,6 @@ import vue from '@vitejs/plugin-vue';
 import { resolve } from 'path';
 import LodashWebpackPlugin from 'lodash-webpack-plugin';
 
-console.log(resolve(__dirname, ''));
-
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [vue(), new LodashWebpackPlugin({ function: true })],

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,6 +41,13 @@
   dependencies:
     "@babel/types" "^7.12.13"
 
+"@babel/helper-module-imports@^7.0.0-beta.49":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz#c6a369a6f3621cb25da014078684da9196b61977"
+  integrity sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==
+  dependencies:
+    "@babel/types" "^7.13.12"
+
 "@babel/helper-split-export-declaration@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz#e9430be00baf3e88b0e13e6f9d4eaf2136372b05"
@@ -95,7 +102,7 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.12.0", "@babel/types@^7.12.13", "@babel/types@^7.13.0", "@babel/types@^7.13.14", "@babel/types@^7.6.1", "@babel/types@^7.7.0", "@babel/types@^7.9.6":
+"@babel/types@^7.0.0-beta.49", "@babel/types@^7.12.0", "@babel/types@^7.12.13", "@babel/types@^7.13.0", "@babel/types@^7.13.12", "@babel/types@^7.13.14", "@babel/types@^7.6.1", "@babel/types@^7.7.0", "@babel/types@^7.9.6":
   version "7.13.14"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.13.14.tgz#c35a4abb15c7cd45a2746d78ab328e362cbace0d"
   integrity sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==
@@ -419,6 +426,17 @@ babel-eslint@^10.1.0:
     "@babel/types" "^7.7.0"
     eslint-visitor-keys "^1.0.0"
     resolve "^1.12.0"
+
+babel-plugin-lodash@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz#4f6844358a1340baed182adbeffa8df9967bc196"
+  integrity sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0-beta.49"
+    "@babel/types" "^7.0.0-beta.49"
+    glob "^7.1.1"
+    lodash "^4.17.10"
+    require-package-name "^2.0.1"
 
 babel-walk@3.0.0-canary-5:
   version "3.0.0-canary-5"
@@ -1214,7 +1232,7 @@ glob-parent@^5.0.0, glob-parent@~5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@~7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@~7.1.1:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -1694,6 +1712,13 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
+lodash-webpack-plugin@^0.11.6:
+  version "0.11.6"
+  resolved "https://registry.yarnpkg.com/lodash-webpack-plugin/-/lodash-webpack-plugin-0.11.6.tgz#8204c6b78beb62ce5211217dfe783c21557ecd33"
+  integrity sha512-nsHN/+IxZK/C425vGC8pAxkKJ8KQH2+NJnhDul14zYNWr6HJcA95w+oRR7Cp0oZpOdMplDZXmjVROp8prPk7ig==
+  dependencies:
+    lodash "^4.17.20"
+
 lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
@@ -1714,7 +1739,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@^4.0.0, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@~4.17.10:
+lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@~4.17.10:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -2490,6 +2515,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+require-package-name@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/require-package-name/-/require-package-name-2.0.1.tgz#c11e97276b65b8e2923f75dabf5fb2ef0c3841b9"
+  integrity sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk=
 
 resolve-from@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2393,6 +2393,11 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
+ramda@^0.27.1:
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
+  integrity sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==
+
 raw-loader@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-4.0.2.tgz#1aac6b7d1ad1501e66efdac1522c73e59a584eb6"


### PR DESCRIPTION
# [Vue3] auto complete practices
**套件自行看 package.json**，目前有使用到 `setup` 的部分
* computed
* watch
* data (ref)
* element ref
* split file

## vue3 練習項目
* main feature : auto complete using composition api
* vite vue router : `src/router.js`


## 其他練習包含
* eslint, prettier
* lodash partial install (function) : see vite.config.js
* bootstrap (style only) : see `src/assets/base-style.scss`
